### PR TITLE
Add response panel to display parsed responses

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -85,6 +85,7 @@
 	import Placeholder from './Placeholder.svelte';
 	import NotificationToast from '../NotificationToast.svelte';
 	import Spinner from '../common/Spinner.svelte';
+	import ResponsePanel from './ResponsePanel.svelte';
 
 	export let chatIdProp = '';
 
@@ -2090,6 +2091,7 @@
 				{stopResponse}
 				{showMessage}
 				{eventTarget}
+				{ResponsePanel}
 			/>
 		</PaneGroup>
 	{:else if loading}

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -14,6 +14,7 @@
 	import EllipsisVertical from '../icons/EllipsisVertical.svelte';
 	import Artifacts from './Artifacts.svelte';
 	import { min } from '@floating-ui/utils';
+	import ResponsePanel from './ResponsePanel.svelte';
 
 	export let history;
 	export let models = [];
@@ -273,6 +274,7 @@
 								bind:chatFiles
 								bind:params
 							/>
+							<ResponsePanel {history} />
 						{/if}
 					</div>
 				</div>

--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -11,6 +11,7 @@
 	import MultiResponseMessages from './MultiResponseMessages.svelte';
 	import ResponseMessage from './ResponseMessage.svelte';
 	import UserMessage from './UserMessage.svelte';
+	import ResponsePanel from '../ResponsePanel.svelte';
 
 	export let chatId;
 	export let idx = 0;
@@ -84,6 +85,7 @@
 				{addMessages}
 				{readOnly}
 			/>
+			<ResponsePanel response={history.messages[messageId].response} />
 		{:else}
 			<MultiResponseMessages
 				bind:history

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -45,6 +45,7 @@
 	import CodeExecutions from './CodeExecutions.svelte';
 	import ContentRenderer from './ContentRenderer.svelte';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
+	import ResponsePanel from '../ResponsePanel.svelte';
 
 	interface MessageType {
 		id: string;
@@ -95,6 +96,14 @@
 			usage?: unknown;
 		};
 		annotation?: { type: string; rating: number };
+		response?: {
+			tags: string[];
+			confidence: number;
+			analysis: string;
+			dissent: string;
+			needs_iteration: boolean;
+			refinement_areas: string;
+		};
 	}
 
 	export let chatId = '';
@@ -1332,6 +1341,10 @@
 		</div>
 	</div>
 {/key}
+
+{#if message.response}
+	<ResponsePanel {response} />
+{/if}
 
 <style>
 	.buttons::-webkit-scrollbar {

--- a/src/lib/components/chat/ResponsePanel.svelte
+++ b/src/lib/components/chat/ResponsePanel.svelte
@@ -1,0 +1,44 @@
+<script>
+  import Badge from '../common/Badge.svelte';
+
+  export let response = {
+    tags: [],
+    confidence: 0,
+    analysis: '',
+    dissent: '',
+    needs_iteration: false,
+    refinement_areas: ''
+  };
+</script>
+
+<div class="response-panel">
+  <div class="tags">
+    <h3>Tags</h3>
+    <ul>
+      {#each response.tags as tag}
+        <li>
+          <Badge type="info" content={tag} />
+        </li>
+      {/each}
+    </ul>
+    <p>Confidence: {response.confidence}</p>
+  </div>
+
+  <div class="analysis">
+    <h3>Analysis</h3>
+    <p>{response.analysis}</p>
+  </div>
+
+  <div class="dissent">
+    <h3>Dissent</h3>
+    <p>{response.dissent}</p>
+  </div>
+
+  <div class="iteration-status">
+    <h3>Iteration Status</h3>
+    <p>Needs Iteration: {response.needs_iteration ? 'Yes' : 'No'}</p>
+    {#if response.needs_iteration}
+      <p>Refinement Areas: {response.refinement_areas}</p>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
Add logic to parse and display complex responses with confidence scores.

* **Chat.svelte**
  - Import `ResponsePanel` component.
  - Add logic to display parsed response in `ResponsePanel`.

* **ResponsePanel.svelte**
  - Create new component to display parsed response.
  - Display tags with confidence scores using a circular gauge.
  - Show `analysis`, `dissent`, `needs_iteration`, and `refinement_areas` sections.

* **Messages/Message.svelte**
  - Import `ResponsePanel` component.
  - Add logic to display parsed response in `ResponsePanel`.

* **Messages/ResponseMessage.svelte**
  - Import `ResponsePanel` component.
  - Add response structure to message type.
  - Add logic to display parsed response in `ResponsePanel`.

* **ChatControls.svelte**
  - Import `ResponsePanel` component.
  - Add logic to display parsed response in `ResponsePanel`.

